### PR TITLE
20260412 문제풀이

### DIFF
--- a/wooseok/11501_주식.py
+++ b/wooseok/11501_주식.py
@@ -1,0 +1,28 @@
+import sys
+
+input = lambda: sys.stdin.readline().rstrip()
+
+# main code
+
+"""
+최대이익: 최대 cost에서 판매
+어떠한 시점에서 구매는 최대 1회만 가능
+역순으로 최댓값 탐색
+
+-> max_price - prices[i]로 차익 계산
+"""
+T = int(input())
+for tc in range(T):
+    n = int(input())
+    prices = [*map(int, input().split())]
+    
+    res = 0
+    max_price = 0
+    
+    for i in range(n - 1, -1, -1):
+        if prices[i] > max_price:
+            max_price = prices[i]
+        else:
+            res += max_price - prices[i]
+        
+    print(res)

--- a/wooseok/2138_전구와_스위치.py
+++ b/wooseok/2138_전구와_스위치.py
@@ -1,0 +1,53 @@
+import sys
+
+input = lambda: sys.stdin.readline().rstrip()
+
+INF = int(1e9)
+
+"""
+1. 전구를 누르는 순서는 상관없음
+  -> 앞에서부터 순서대로 누른다면 앞에서 부터 전구의 상태를 고정시킬 수 있음
+  -> index i기준 i-1만 신경쓰자
+2. 1번 또는 N번 위치를 누를 때만 특이 케이스 존재
+  -> 누르는 순서는 상관없고 둘 중 하나는 다른 하나에 종속됨
+  -> 첫 번째 전구를 누르는 경우와 누르지 않는 경우로 구분
+=> 그리디
+"""
+
+# main code
+n = int(input())
+a = [*map(int, input())]
+b = [*map(int, input())]
+
+if a == b:
+    print(0)
+    sys.exit()
+
+def flip(state, i):
+    for j in range(i - 1, i + 2):
+        if 0 <= j < n:
+            state[j] ^= 1
+
+def run(first):
+    state = a[:]
+    cnt = 0
+    
+    if first:
+        flip(state, 0)
+        cnt += 1
+    
+    for i in range(1, n):
+        if state[i - 1] != b[i - 1]:
+            flip(state, i)
+            cnt += 1
+    
+    if state == b:
+        return cnt
+    else:
+        return INF
+
+res1 = run(True)
+res2 = run(False)
+
+res = min(res1, res2)
+print(res if res != INF else -1)


### PR DESCRIPTION
## 관련 Issue
issue: #9, #10

## 풀이 설명
### 2138 전구와 스위치

<!-- 풀이 접근법 -->
1. 전구를 누르는 순서는 상관없음
  -> 앞에서부터 순서대로 누른다면 앞에서 부터 전구의 상태를 고정시킬 수 있음
  -> index i기준 i-1만 신경쓰자
2. 1번 또는 N번 위치를 누를 때만 특이 케이스 존재
  -> 누르는 순서는 상관없고 둘 중 하나는 다른 하나에 종속됨
  -> 첫 번째 전구를 누르는 경우와 누르지 않는 경우로 구분
=> 그리디

경우의 수를 나눠서 둘 중 더 적은 횟수를 채택하는 방식

### 11501 주식

<!-- 풀이 접근법 -->
최대이익: 최대 cost에서 판매
어떠한 시점에서 구매는 최대 1회만 가능
역순으로 최댓값 탐색

-> max_price - prices[i]로 차익 계산


## 시간/공간 복잡도
| 문제 | 시간 | 공간 |
|------|------|------|
| 전구와 스위치 | 120ms O(2N) | 119484KB |
| 주식 | 1292ms O(N * T) | 333028KB |
