### PR TITLE
0413 문제 풀이

### DIFF
--- a/minjun/11501.py
+++ b/minjun/11501.py
@@ -1,0 +1,30 @@
+import sys
+input = sys.stdin.readline
+
+T = int(input())
+for _ in range(T):
+    n = int(input())
+    prices = list(map(int, input().split()))
+
+    cum_prices = [0]
+    for price in prices:
+        cum_prices.append(cum_prices[-1]+price)
+    
+    prices = [(price, idx) for idx, price in enumerate(prices)]
+    prices.sort(reverse=True)
+    
+    profit = 0
+    cur_pos = 0
+    for max_price, idx in prices:
+        if idx == cur_pos:
+            cur_pos += 1
+            continue
+        elif idx < cur_pos:
+            continue
+        else:
+            profit += (idx - cur_pos) * max_price - (cum_prices[idx] - cum_prices[cur_pos])
+            cur_pos = idx + 1
+            if idx == n-1:
+                break
+    
+    print(profit)


### PR DESCRIPTION
## 관련 Issue
issue: #9, #10

## 풀이 설명
### 문제 1
<!-- 풀이 접근법 -->
가장 높은 주가가 될 때까지 전부 사고, 높은 주가 도달했을 때 팔면 됨.
그 다음으로 높은 주가가 될 때까지 전부 사고, 해당 주가 도달했을 때 팔면 됨.

순서상 주가 최고가가 어디인지 정해져야,
해당 주가까지의 합을 구하고 이익을 계산할 수 있는데,
리스트를 반복해서 순회하게 됨.
이를 위해 누적합을 따로, 주가 정렬을 따로 하여 연산을 최소화 함.

1. 누적합 리스트 생성
2. 주가 내림차순 정렬
3. 현재 위치로부터 해당 주가까지의 이익 계산
4. 현재 위치 조정
3 ~ 4 반복 (현재 위치가 마지막 위치가 될 때 까지)

### 문제 2
<!-- 풀이 접근법 -->
못풀었음...
규칙을 제대로 못 찾겠음..

## 시간/공간 복잡도
| 문제 | 시간 | 공간 |
|------|------|------|
| 문제 1 | O(N+NlogN) | O(2N)? 3N? |
| 문제 2 | - | - |
