### PR TITLE
260415

### DIFF
--- a/dong99u/11003.py
+++ b/dong99u/11003.py
@@ -1,0 +1,26 @@
+import sys; input = lambda: sys.stdin.readline().rstrip()
+from collections import deque
+
+'''
+Q = 빈 큐 (값, 인덱스) 리스트 -> Q[0]은 항상 최솟값 유지
+arr 를 모두 순회하면서 만약 new가 Q[-1]보다 작다면(new < Q[-1]) 그 Q에 있는 값들은 출력될 일이 없음 (빼기)
+'''
+
+MAX_SIZE = 10 ** 6
+
+n, l = map(int, input().split())
+arr = list(map(int, input().split()))
+
+Q = deque()
+result = []
+for i in range(n):
+    # 윈도우 벗어난 원소 제거 (앞에서)
+    if Q and i - Q[0][1] >= l:
+        Q.popleft()
+    # 새 원소보다 큰 원소 제거 (뒤에서)
+    while Q and arr[i] < Q[-1][0]:
+        Q.pop()
+    Q.append((arr[i], i))
+    result.append(Q[0][0])  # 항상 실행
+
+print(*result)

--- a/dong99u/17245.py
+++ b/dong99u/17245.py
@@ -1,0 +1,32 @@
+import sys; input = lambda: sys.stdin.readline().rstrip()
+
+MAX_SIZE = 10 ** 7
+
+
+def is_valid(mid):
+    count = 0
+    for i in range(n):
+        for j in range(n):
+            count += min(mid, grid[i][j])
+    return count >= thresh_hold
+
+def search():
+    left, right = 0, MAX_SIZE
+    result = MAX_SIZE
+
+    while left <= right:
+        mid = (left + right) // 2
+        if is_valid(mid):
+            right = mid - 1
+            result = min(result, mid)
+        else:
+            left = mid + 1
+    return result
+
+n = int(input())
+grid = [list(map(int, input().split())) for _ in range(n)]
+
+total = sum(grid[i][j] for i in range(n) for j in range(n))
+thresh_hold = total / 2
+
+print(search())


### PR DESCRIPTION
## 관련 Issue
issue: #19 , #21 , #23 

## 풀이 설명
### 숫자 할리갈리 게임
<!-- 풀이 접근법 -->
덱은 deque, 그라운드는 stack으로 구현한다. 입력은 바닥→위 순서로 주어지므로 appendleft로 삽입해 popleft 시 맨 위 카드가 먼저 나오게 한다.
메인 루프는 M번 개별 진행이므로 i % 2로 도도와 수연의 턴을 번갈아 처리한다. 각 턴에서 카드를 그라운드에 내려놓은 직후, 종 조건 체크 이전에 덱이 비었는지 확인해 즉시 승패를 결정한다.
종 조건은 두 가지다. 도도는 어느 쪽 그라운드 맨 위 카드라도 5이면 종을 치고, 수연은 두 그라운드가 모두 비어있지 않으면서 맨 위 카드 합이 5이면 종을 친다. 두 조건이 동시에 성립할 수 있으므로 도도 조건과 수연 조건을 독립적으로 순서대로 체크한다.
카드 회수 시 그라운드를 "뒤집어 덱 아래로 합친다"는 규칙은 deque.extend(ground)로 구현한다. 이렇게 하면 그라운드 바닥 카드(인덱스 0)가 덱에서 먼저 나오는 순서가 보장된다.
M번 진행 후 승자가 없으면 덱 크기를 비교해 승패 또는 무승부를 결정한다.

### 함께 블록 쌓기
<!-- 풀이 접근법 -->
#### 메모이제이션 적용 전 — 백트래킹
가장 직관적인 접근은 백트래킹이다. 각 학생마다 "사용 안 함" 또는 "블록 k 선택"을 재귀적으로 시도하고, N번 학생까지 모두 고려한 뒤 높이가 H이면 1을 반환한다. 이 방식의 시간복잡도는 각 학생이 최대 M+1가지 선택지를 가지므로 O((M+1)^N)이며, N=50, M=10일 때 11^50으로 시간 내에 절대 해결할 수 없다.
#### 탑-바텀(Memoization), 바텀-업(Tabulation)
Well-Known 문제는 Tabulation 쓸 수 있는데, 아닌 건 백트래킹으로 풀어보다가 메모이제이션으로 푸는 게 더 편해서 이것 밖에 생각이 안 났다.
 
#### 동일한 상황 분석
어떤 시점에서 남은 학생들의 블록을 선택하려는 미래의 입장에서, 결과에 영향을 주는 정보는 두 가지이다. 첫째는 지금까지 고려한 학생의 번호, 둘째는 지금까지 쌓은 탑의 높이이다. 이 두 값이 같다면 어떤 경로로 그 상태에 도달했든 앞으로의 선택지가 완전히 동일하므로, 같은 상태로 취급할 수 있다.

백트래킹 과정에서 서로 다른 선택 경로가 동일한 (i, acc) 상태에 여러 번 도달하게 된다. 예를 들어 1번 학생이 높이 2 블록을 쓰고 2번 학생이 높이 3 블록을 쓴 경우와, 1번 학생이 높이 3 블록을 쓰고 2번 학생이 높이 2 블록을 쓴 경우는 모두 (3, 5) 상태에서 만나며, 이후 탐색이 완전히 동일하다. 이런 중복 계산을 제거하기 위해 (i, acc) 쌍에 대한 결과를 메모에 저장하고 재활용하면 된다.

#### 메모이제이션 적용 후 복잡도
상태 공간은 i가 0부터 N, acc가 0부터 H이므로 총 O(N × H)개이다. 각 상태에서 최대 M+1가지 상태 갈래가 있으므로, 시간복잡도는 O(N × H × M) 이다. N=50, H=1000, M=10일 때 약 550,000번의 연산으로 충분히 시간 내에 해결된다. 공간복잡도 =  O(N × H)


### 좋다
<!-- 풀이 접근법 -->
배열을 정렬한 뒤, 각 원소를 "target"으로 잡고 투 포인터로 나머지 원소 중 두 개의 합이 target과 같은 쌍이 존재하는지 탐색한다. 
left는 배열 맨 앞, right는 맨 뒤에서 출발해서 합이 target보다 작으면 left를 오른쪽으로, 크면 right를 왼쪽으로 좁혀가고, 같으면 유효한 쌍을 찾은 것이다.

#### 시간 복잡도
정렬에 O(NlogN) 이 걸리지만 루프 때문에 O(N²)이 된다.

## 시간/공간 복잡도
| 문제 | 시간 | 공간 |
|------|------|------|
| 문제 1 | O(M) | O(N) |
| 문제 2 | O(N x H) | O(N x H) |
| 문제 3 | O(N²) |  |
