### PR TITLE
20260417 #22 #30

### DIFF
--- a/minuk/11003.py
+++ b/minuk/11003.py
@@ -1,0 +1,16 @@
+from sys import stdin
+import heapq
+
+n, l = map(int, stdin.readline().split())
+ary = map(int, stdin.readline().split())
+min_heap = []
+res = [0 for i in range(n)]
+i = 0
+for data in ary:
+	m = i - l
+	while (len(min_heap) != 0 and min_heap[0][1] <= m):
+		heapq.heappop(min_heap)
+	heapq.heappush(min_heap, (data, i))
+	res[i] = min_heap[0][0]
+	i += 1
+print(*res)

--- a/minuk/17245.py
+++ b/minuk/17245.py
@@ -1,0 +1,30 @@
+import sys;input=lambda:sys.stdin.readline().rstrip()
+
+N = int(input())
+ary = [[*map(int, input().split())] for i in range(N)]
+
+def check(t):
+    count = 0
+    for i in range(N):
+        for j in range(N):
+            count += min(t, ary[i][j])
+    return count >= total
+
+total = sum(sum(ary[i]) for i in range(N)) + 1
+total >>= 1
+left, right = 0, int(1e7) + 1
+ans = right
+while (left <= right):
+    mid = (left + right) >> 1
+    if (check(mid)):
+        ans = min(ans, mid)
+        right = mid - 1
+    else: left = mid + 1
+print(ans)
+
+
+# 값이 매우 크고 최적화 문제인 경우 그냥 구현으로는 풀 수 없음
+# 매개 변수 탐색으로 최적화 문제를 선택 문제로 바꾸어야 하는 문제
+# 서버실의 컴퓨터 중 절반 이상이 켜지기 위해 필요한 최소 시간 (최적화 문제) -> 시간이 k일 때, 서버실의 컴퓨터 중 절반이 켜지는가? (선택 문제)
+# 이때의 k 값이 범위가 정해져있으므로 이분 탐색으로 구할 수 있음
+# 그래서 시간은 전체 시뮬레이션 시간 N^2에 이분 탐색 시간 log(1e7)이므로 O(N^2 * log(1e7))이 됨


### PR DESCRIPTION
## 관련 Issue
issue: #22, #30

## 풀이 설명
### 서버실
값이 매우 크고 최적화 문제인 경우 그냥 구현으로는 풀 수 없음
매개 변수 탐색으로 최적화 문제를 선택 문제로 바꾸어야 하는 문제
서버실의 컴퓨터 중 절반 이상이 켜지기 위해 필요한 최소 시간 (최적화 문제) -> 시간이 k일 때, 서버실의 컴퓨터 중 절반이 켜지는가? (선택 문제)
이때의 k 값이 범위가 정해져있으므로 이분 탐색으로 구할 수 있음
그래서 시간은 전체 시뮬레이션 시간 N^2에 이분 탐색 시간 log(1e7)이므로 O(N^2 * log(1e7))이 됨
시뮬레이션은 잘 구현하면 시간 줄일 수 있어보임

### 최솟값 찾기
priority queue를 이용해서 최소힙 만들기
삽입할 때 idx 값도 같이 넣어서 현재 보는 값과 idx와의 차이를 비교해서, 구간보다 크면 빼내기
매번 삽입할 때마다 최소힙에서의 최솟값 추가

## 시간/공간 복잡도
| 문제 | 시간 | 공간 |
|------|------|------|
| 문제 1 | O(N^2 * log(1e7)) | O(N^2) |
| 문제 2 | O(2NlogN) | O(3N) |
