### PR TITLE
20260417 #22 #30

### DIFF
--- a/sukyung/11003.py
+++ b/sukyung/11003.py
@@ -1,0 +1,30 @@
+# 최솟값 찾기 - Gold 1
+
+import sys
+input = sys.stdin.readline
+from collections import deque
+
+N, L = map(int, input().split())
+arr = list(map(int, input().split()))
+
+d = []
+q = deque()
+
+for i in range(N):
+    # 삽입하려는 arr[i]보다 값이 크다면 앞으로 절대 최솟값이 될 수 없으므로 pop
+    # while 반복문으로 인해 기존에 queue에 있던 값 중
+    # arr[i]보다 큰 값은 존재하지 않게 됨
+    # -> 가장 작은 값이 queue의 맨 앞에 위치하게 되고, 순서대로 정렬됨
+    while q and q[-1][0] > arr[i]:
+        q.pop()
+    # 현재 값과 index 함께 삽입
+    q.append((arr[i], i))
+    # 최솟값의 index가 범위 밖이라면 pop
+    if q[0][1] < i-L+1: # 매번 범위가 1씩 움직이므로 while이 아닌 if문으로 처리 가능
+        q.popleft()
+    # => 현재 범위 중, 가장 작은 값이 queue의 맨 앞에 위치하게 됨
+
+    # 해당 범위의 최솟값 d에 저장
+    d.append(q[0][0])
+
+print(*d)

--- a/sukyung/17245.py
+++ b/sukyung/17245.py
@@ -1,0 +1,49 @@
+# 서버실 - Silver 2
+
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+comp = []
+for _ in range(N):
+    comp.extend(map(int, input().split()))  # 1차원 배열로 변환
+comp_sum = sum(comp)
+
+# 1. 정렬 후 시간과 비교해서 계산
+comp.sort()
+target = (comp_sum + 1) // 2    # 목표인 컴퓨터 절반 수
+t = 0
+s = N*N  # len(comp): N*N 칸 이므로
+on = 0  # 켜진 컴퓨터 수
+i = 0
+
+while on < target:
+    # 현재 시간 t보다 큰 값(컴퓨터 수)을 가지고 있는 idx 찾기
+    while i < s and comp[i] <= t:
+        i += 1
+    on += (s - i)   # 이번 t 시간에 켜질 컴퓨터의 수
+    t += 1
+
+print(t)
+
+
+# 2. 이분탐색 사용
+# start, end = 0, max(comp)
+# # 모든 컴퓨터가 다 켜지는 데 걸리는 최대 시간 = max(comp)
+# target = (comp_sum + 1) // 2  # target이 되는 컴퓨터 절반
+# t = 0  # 걸린 시간
+
+# while start <= end:
+#     mid = (start + end) // 2   # mid: 걸린 시간
+#     on = 0  # 켜진 컴퓨터의 수
+#     for c in comp:
+#         # 만약 쌓인 컴퓨터 수가 걸린 시간보다 작다면 모두 켜졌을 것이고,
+#         # 아니라면 걸린 시간만큼만 컴퓨터가 켜졌을 것이다.
+#         on += (c if c < mid else mid)
+#     if on >= target:    # 절반 이상의 컴퓨터가 켜졌다면
+#         t = mid  # 우선 정답으로 걸린 시간인 mid 저장
+#         end = mid - 1   # 더 최소 시간이 존재하는지 검사
+#     else:   # 아직 절반 미만의 컴퓨터가 켜졌다면
+#         start = mid + 1  # start를 옮겨 더 큰 걸린 시간으로 검사 진행
+
+# print(t)


### PR DESCRIPTION
## 관련 Issue
issue: #22 , #30 

## 풀이 설명
### 문제 1 - 서버실
서버실을 굳이 2차원 배열로 검사할 필요 없기 때문에, 1차원 리스트로 변환해서 저장
1. 정렬 후, 현재 시간과 비교해서 켜지는 컴퓨터 수 계산
예를 들어, [0,0,1,2,3,3] 이렇게 서버실 컴퓨터가 있다면, 
t=1: 4대 켜지고
t=2: 3대 켜지고
t=3: 2대 켜지므로
이를 누적합하고 총 컴퓨터의 절반 수와 비교해주면 된다.

2. 이분탐색 방법
알고리즘 분류에 이분탐색이 있길래 궁금해서 찾아본 방법
총 컴퓨터의 절반 이상이 켜지는 데 걸리는 시간을 이분탐색 방법을 사용해서 탐색
모든 컴퓨터가 다 켜지는 데 걸리는 최대 시간이 max(comp)이므로 이를 초기 end로 설정해 mid 값을
걸린 시간으로 설정해 비교
모든 서버실의 칸에 대해  걸린 시간 or 컴퓨터 수 둘 중 몇 대 만큼 컴퓨터가 켜졌을지 비교해 합한다.
이 과정을 반복해 최소 걸린 시간을 찾는다.

### 문제 2 - 최솟값 찾기
deque 사용
매번 범위가 1씩 움직임
새로운 값 삽입할 때, 기존에 있던 값 비교해서 더 크면 pop
index도 함께 저장해서 범위 비교도 해줌
이 과정을 거치면, 매번 queue에 현재 범위 중, 최솟값이 queue의 맨 앞에 위치하게 되므로 이를 d에 저장하면 됨

## 시간/공간 복잡도
| 문제 | 시간 | 공간 |
|------|------|------|
| 문제 1 | O(N^2*log10**6),  | O(N^2) |
| 문제 2 | O(N) | O(N) |
