### PR TITLE
chore: issue 라인에 추가 정보가 있어도 숫자만 파싱하도록 수정

### DIFF
--- a/.github/scripts/auto-close-issue.js
+++ b/.github/scripts/auto-close-issue.js
@@ -16,7 +16,7 @@ module.exports = async ({ github, context }) => {
   }
 
   const issueNumbers = [...issueLineMatch[1].matchAll(/#(\d+)\b/g)]
-    .map(m => parseInt(m[1]));
+    .map(m => parseInt(m[1], 10));
   if (issueNumbers.length === 0) {
     console.log("Error: Can't find issue numbers from issue line");
     return;

--- a/.github/scripts/auto-close-issue.js
+++ b/.github/scripts/auto-close-issue.js
@@ -9,14 +9,18 @@ module.exports = async ({ github, context }) => {
   const pr = context.payload.pull_request;
   const body = pr.body || '';
 
-  const issueLineMatch = body.match(/issue:\s*((?:#\d+[\s,]*)+)/i);
+  const issueLineMatch = body.match(/^issue:\s*(.+)$/im);
   if (!issueLineMatch) {
     console.log("Error: Can't find issue numbers from PR");
     return;
   }
 
-  const issueNumbers = [...issueLineMatch[1].matchAll(/#(\d+)/g)]
+  const issueNumbers = [...issueLineMatch[1].matchAll(/#(\d+)\b/g)]
     .map(m => parseInt(m[1]));
+  if (issueNumbers.length === 0) {
+    console.log("Error: Can't find issue numbers from issue line");
+    return;
+  }
   console.log(`connected Issue: ${issueNumbers.map(n => '#' + n).join(', ')}`);
 
   for (const issueNum of issueNumbers) {


### PR DESCRIPTION
```js
const issueLineMatch = body.match(/^issue:\s*(.+)$/im);
if (!issueLineMatch) {
  console.log("Error: Can't find issue numbers from PR");
  return;
}

const issueNumbers = [...issueLineMatch[1].matchAll(/#(\d+)\b/g)]
  .map(m => parseInt(m[1]));
```

이슈 라인 전체를 파싱해서 #직후에 있는 숫자만 파싱하도록 수정