### PR TITLE
20260422 #41

### DIFF
--- a/dong99u/2169.java
+++ b/dong99u/2169.java
@@ -1,0 +1,73 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	// 가로 세로 크기
+	static int n;
+	static int m;
+	static int[][] grid; // 격자
+
+	static final int L = 0;
+	static final int R = 1;
+	static final int D = 2;
+	static final int INF = (int) 1e9;
+
+	public static void main(String[] args) throws IOException {
+		init();
+
+		int[][][] dp = new int[n][m][3];
+		for (int i = 0; i < n; i++) {
+			for (int j = 0; j < m; j++) {
+				Arrays.fill(dp[i][j], -INF);
+			}
+		}
+		dp[0][0][D] = grid[0][0];
+
+		// 0행: 오른쪽 방향으로만 확장 (시작점에서 왼쪽은 갈 수 없음)
+        for (int j = 1; j < m; j++) {
+            int prev = Math.max(dp[0][j - 1][R], dp[0][j - 1][D]);
+            if (prev != -INF) {
+                dp[0][j][R] = grid[0][j] + prev;
+            }
+        }
+
+		for (int i = 1; i < n; i++) {
+			for (int j = 0; j < m; j++) {
+				dp[i][j][D] = grid[i][j] + Arrays.stream(dp[i - 1][j]).max().getAsInt();
+				if (inRange(i, j - 1)) {
+					dp[i][j][R] = grid[i][j] + Math.max(dp[i][j - 1][D], dp[i][j - 1][R]);
+				}
+			}
+			for (int j = m - 1; j >= 0; j--) {
+				if (inRange(i, j + 1)) {
+					dp[i][j][L] = grid[i][j] + Math.max(dp[i][j + 1][D], dp[i][j + 1][L]);
+				}
+			}
+		}
+
+		int answer = Arrays.stream(dp[n - 1][m - 1]).max().getAsInt();
+		System.out.println(answer);
+
+	}
+
+	static boolean inRange(int x, int y) {
+		return (0 <= x && x < n) && (0 <= y && y < m);
+	}
+
+	static void init() throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+
+		grid = new int[n][m];
+
+		for (int i = 0; i < n; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < m; j++) {
+				grid[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+	}
+}


### PR DESCRIPTION
 - 2169: 로봇 조종하기

## 관련 Issue
issue: #41 

## 풀이 설명
### 문제 1 [로봇 조종하기]
<!-- 풀이 접근법 -->
두 개의 서로 다른 경로로 같은 위치 (r, c)에 도달 가능. 
경로 A: (0,0) → (1,0)
경로 B: (0,0) → (0,1) → (1,1) → (1,0)
하지만 단방향으로만 움직이는 문제가 아니고, 재방문이 불가능하다는 조건이 있으므로 이전에 어디서 왔는지에 따라서 다음 선택지가 정해짐. 

1. 진입한 자리에서 바로 아래로 (이 행에서 추가 이동 없음)
2. 진입한 자리에서 쭉 오른쪽으로만 가다가 아래로
3. 진입한 자리에서 쭉 왼쪽으로만 가다가 아래로

이 세 가지의 이동만 가능.

```
dp[r][c][d] = (0, 0)에서 출발해서 (r, c)에 방향 d로 도착했을 때
              가능한 최대 누적 가치 (도착 칸의 가치 arr[r][c] 포함)
```

### 점화식
```
dp[r][c][아래]   = arr[r][c] + max(dp[r-1][c][아래], dp[r-1][c][오른쪽], dp[r-1][c][왼쪽])
dp[r][c][오른쪽] = arr[r][c] + max(dp[r][c-1][아래], dp[r][c-1][오른쪽])
                              # dp[r][c-1][왼쪽]은 제외 — 오른쪽 이동 불가
dp[r][c][왼쪽]   = arr[r][c] + max(dp[r][c+1][아래], dp[r][c+1][왼쪽])
                              # dp[r][c+1][오른쪽]은 제외 — 왼쪽 이동 불가
```

## 시간/공간 복잡도
| 문제 | 시간 | 공간 |
|------|------|------|
| 문제 1 | O(N * M) | O(N * M) |

