### PR TITLE
260424 #38 #42

### DIFF
--- a/dong99u/14889.java
+++ b/dong99u/14889.java
@@ -1,0 +1,64 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	static final int MAX_VALUE = (int) 1e9;
+
+    static int n;
+    static int[][] grid;
+    static boolean[] inA;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        inA[0] = true;
+        int answer = splitTeams(1, 1);
+        System.out.println(answer);
+    }
+
+    /**
+     * 현재 inA 상태에서, start 이후를 A팀에 어떻게 채우든
+     * 얻을 수 있는 "최소 diff"를 리턴.
+     */
+    static int splitTeams(int start, int count) {
+        // 기저: A팀이 다 차면 이 분할에 대한 diff가 바로 답
+        if (count == n / 2) {
+            return getDiff();
+        }
+
+        int best = MAX_VALUE;
+        for (int i = start; i < n; i++) {
+            inA[i] = true;
+            int sub = splitTeams(i + 1, count + 1);
+            inA[i] = false;
+
+            if (sub < best) best = sub;
+        }
+        return best;
+    }
+
+    static int getDiff() {
+        int sumA = 0, sumB = 0;
+        for (int i = 0; i < n; i++) {
+            for (int j = i + 1; j < n; j++) {
+                int s = grid[i][j] + grid[j][i];
+                if (inA[i] && inA[j])        sumA += s;
+                else if (!inA[i] && !inA[j]) sumB += s;
+            }
+        }
+        return Math.abs(sumA - sumB);
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        grid = new int[n][n];
+        inA = new boolean[n];
+
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) {
+                grid[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+    }
+}

--- a/dong99u/9935.java
+++ b/dong99u/9935.java
@@ -1,0 +1,35 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	static String arr;
+	static String explosiveStr;
+	static int n;
+	static int m;
+	public static void main(String[] args) throws IOException {
+		init();
+
+		StringBuilder stack = new StringBuilder();
+
+		for (int i = 0; i < n; i++) {
+			stack.append(arr.charAt(i));
+
+			if (stack.length() >= m) {
+				String top = stack.substring(stack.length() - m);
+				if (top.equals(explosiveStr)) {
+					stack.delete(stack.length() - m, stack.length());  // pop m개
+				}
+			}
+		}
+
+		System.out.println(stack.isEmpty() ? "FRULA" : stack.toString());
+	}
+
+	static void init() throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		arr = br.readLine();
+		n = arr.length();
+		explosiveStr = br.readLine();
+		m = explosiveStr.length();
+	}
+}


### PR DESCRIPTION
- 14889 스타트와 링크 (실버)
- 9935 문자열 폭발 (골드)

## 관련 Issue
issue: #38 , #42 

## 풀이 설명
### 문제 1 [14889 스타트와 링크]
<!-- 풀이 접근법 -->
N <= 20 이므로 완탐 해도 됨.
SWEA 요리사 문제처럼 조합으로 팀을 나누고, 2-for 로 합을 더해서 팀의 시너지 차이 출력
시너지의 최솟값을 갱신하도록 함.

### 문제 2 [9935 문자열 폭발]
<!-- 풀이 접근법 -->
N <= 10 ** 6 이므로 O(NlogN) 이하로 시간복잡도를 설계해야함. 기존에 생각한 게, 각 문자열을 순회하면서 폭발 문자열 중의 하나라면 삭제 후 다시 for문을 돌도록 함. 이러면 시간초과. 
stack을 이용해서 터지고 난 후를 다시 계산하는 게 아니라 O(N)으로 하도록 하면 될듯 M <= 32 이므로 가능.
 

## 시간/공간 복잡도
| 문제 | 시간 | 공간 |
|------|------|------|
| 문제 1 |   |  |
| 문제 2 |  |  |

