### PR TITLE
20260429 #59 #61 #64

### DIFF
--- a/sukyung/200.py
+++ b/sukyung/200.py
@@ -16,12 +16,11 @@ class Solution:
                     visited[new_i][new_j] = 1
                     dfs(new_i, new_j)  # 내 상하좌우로 연결된 land가 있는지 탐색
 
-
         for i in range(m):
             for j in range(n):
                 # 아직 방문하지 않은 land이면 섬 검사
                 if grid[i][j]=='1' and not visited[i][j]:
-                    visited[i][j] == 1
+                    visited[i][j] = 1
                     dfs(i, j)
                     island += 1
         

--- a/sukyung/200.py
+++ b/sukyung/200.py
@@ -1,0 +1,28 @@
+class Solution:
+    def numIslands(self, grid: List[List[str]]) -> int:
+        m, n = len(grid), len(grid[0])
+        visited = [[0] * n for _ in range(m)]  # land 방문 체크 배열
+        dx = [1, -1, 0, 0]
+        dy = [0, 0, 1, -1]
+        island = 0
+
+        def dfs(i, j):
+            for k in range(4):
+                new_i = i + dx[k]
+                new_j = j + dy[k]
+                # 아직 방문하지 않았고, 현재와 연결된 land인 경우
+                # -> 하나의 섬으로 이어져 있는 경우임
+                if 0<=new_i<m and 0<=new_j<n and not visited[new_i][new_j] and grid[new_i][new_j]=='1':
+                    visited[new_i][new_j] = 1
+                    dfs(new_i, new_j)  # 내 상하좌우로 연결된 land가 있는지 탐색
+
+
+        for i in range(m):
+            for j in range(n):
+                # 아직 방문하지 않은 land이면 섬 검사
+                if grid[i][j]=='1' and not visited[i][j]:
+                    visited[i][j] == 1
+                    dfs(i, j)
+                    island += 1
+        
+        return island

--- a/sukyung/68.py
+++ b/sukyung/68.py
@@ -1,0 +1,39 @@
+from collections import deque
+class Solution:
+    def fullJustify(self, words: List[str], maxWidth: int) -> List[str]:
+        i = 0
+        res = []
+        while i < len(words):
+            width = 0  # 공백 제외한 단어 길이만의 합
+            dq = deque()  # 단어 담을 queue
+            # 현재 단어 길이 + 다음 단어 길이 + 단어 사이에 들어갈 최소 공백 수(각 1칸)이 maxWidth 보다 작은 경우만
+            while i<len(words) and width+len(words[i])+len(dq)<=maxWidth:
+                width += len(words[i])
+                dq.append(words[i])
+                i += 1
+
+            spaces = maxWidth - width  # 단어 길이만을 뺀 총 공백 수
+            s = ""
+            word_len = len(dq)  # 단어 개수
+
+            if i == len(words):  # 마지막 줄인 경우
+                while len(dq) > 1:
+                    s += dq.popleft() + " "
+                s += dq.popleft()
+                s += " " * (spaces-(word_len-1))  # 총 공백 수 - 단어 사이 최소 공백 수
+
+            elif word_len == 1:  # 단어가 하나인 경우
+                s += dq.popleft() + " " * spaces
+
+            else:  # 그 외의 경우: 왼쪽 정렬하지 않는 경우
+                space = spaces // (word_len-1)  # 각 단어 사이에 똑같이 들어갈 최소 공백 수
+                extra_space = spaces % (word_len-1)  # 남은 공백 수: 왼쪽부터 하나씩 더 줄 것임
+                # 단어 사이 개수만큼 반복
+                for j in range(word_len-1):
+                    s += dq.popleft() + (" " * space)
+                    s += " " * (1 if j < extra_space else 0)  # extra_space가 남아있으면 1칸씩 추가 공백
+                s += dq.popleft()
+
+            res.append(s)
+
+        return res

--- a/sukyung/virus_pipe.py
+++ b/sukyung/virus_pipe.py
@@ -1,0 +1,46 @@
+from collections import deque
+from collections import defaultdict
+
+def solution(n, infection, edges, k):
+    answer = 0
+    graph = defaultdict(list)
+    for x, y, type in edges:
+        graph[x].append((y, type))
+        graph[y].append((x, type))
+    
+    infected = [0] * (n+1)  # 감염 여부 나타내는 list
+    infected[infection] = 1
+    cur_infected = [infection]  # 현재까지 감염된 배양체 번호 저장
+    
+    def dfs(i, last_type):
+        nonlocal answer
+        if i == k:
+            answer = max(answer, len(cur_infected))
+            return
+        for type in range(1, 4):
+            # 직전에 열었던 파이프인 경우, 다른 파이프를 열도록 pass
+            if type == last_type: continue
+            
+            # 인접한 배양체 감염 처리
+            new_infected = []  # type 파이프를 통해 새로 감염될 배양체 배열
+            q = deque(cur_infected)  # 연결된 배양체 탐색할 큐
+            while q:
+                node = q.popleft()
+                for next, t in graph[node]:  # 인접한 배양체 탐색
+                    # 아직 감염되지 않았고, 파이프 종류가 같은 경우
+                    if not infected[next] and t==type:
+                        infected[next] = 1  # 감염 처리
+                        cur_infected.append(next)
+                        new_infected.append(next)
+                        q.append(next)
+                        
+            dfs(i+1, type)
+            
+            # 감염 처리 되돌리기
+            for node in new_infected:
+                infected[node] = 0
+                cur_infected.pop()
+                        
+    dfs(0, -1)
+    
+    return answer


### PR DESCRIPTION
## 관련 Issue
issue: #59 , #61 , #64 

## 풀이 설명
### 문제 1 Number of Islands
land 방문 체크하는 2차원 배열 생성
모든 grid에 대해 land이고, 아직 방문하지 않았으면 dfs 탐색 진행
dfs: 현재 land와 연결된 land 탐색 진행하며 방문 처리해 줌

### 문제 2 Text Justification
반복문을 돌리며, words 배열의 끝까지 검사 진행
현재 단어들의 길이+다음 단어 길이+각 단어 사이에 들어갈 공백 1칸 수 <= maxwidth인 경우에만 단어 추가하며 진행
마지막 줄인 경우와 단어가 하나인 경우, 왼쪽 정렬 처리
그 외의 경우, '//' 와 '%' 연산자를 통해 각 단어 사이에 들어갈 최소 공백 수와 왼쪽부터 추가해줄 공백 개수 알아내 추가해줌
단어는 queue를 사용해서 leftpop()으로 하나씩 빼며 진행

### 문제 3 바이러스 파이프
처음에는 현재 감염 배양체를 타고 타고 가서, 파이프 번호에 해당하는 배양체 감염시키는 dfs로 진행하려다
너무 복잡하고 탐색 깊이도 깊어질 것 같아 포기.
=>
[dfs와 bfs 탐색 함께 진행]
deque 활용하여 큐에 감염된 배양체 넣고, 큐가 빌 때까지 인접한 배양체 중 현재 열린 파이프와 연결된 배양체 감염시킴


## 시간/공간 복잡도
| 문제 | 시간 | 공간 |
|------|------|------|
| 문제 1 | O(mn) | O(mn) |
| 문제 2 | O(n*maxWidth) | O(len(res)) |
| 문제 3 | O(2**k*(n+len(edges))) | O(n+len(edges)) |
