### PR TITLE
20260501 #60, #64, #69

### DIFF
--- a/dong99u/leetcode/115.java
+++ b/dong99u/leetcode/115.java
@@ -1,0 +1,63 @@
+package leetcode.leetcode115;
+
+import java.util.*;
+
+/**
+ * 문제
+ * 문자열 s에서 부분수열로 t를 만드는 방법의 수를 구하기.
+ * 1. 처음 생각 (백트래킹부터 시작)
+ * s의 각 글자에 대해 선택/비선택 두 분기로 brute force.
+ *
+ * 상태: (idx, count) — s에서 idx번째까지 봤고, t의 count글자까지 매칭 완료
+ * 선택: s[idx] == t[count]일 때만 가능 → (idx+1, count+1)
+ * 비선택: 항상 가능 → (idx+1, count)
+ *
+ * 2. 복잡도 분석 → 최적화 결정
+ *
+ * Brute force: 분기수 2 × 깊이 n → O(2ⁿ), n=1000이면 타임아웃.
+ * 상태 공간: idx, count 모두 단조 증가 → DAG → 메모이제이션 가능
+ * 같은 (idx, count)에 여러 경로 도달 → 메모이제이션 효과 큼
+ *
+ * → 백트래킹 + 메모이제이션 = O(n·k)
+ */
+
+public class Solution {
+	static String s;
+	static String t;
+	static int n;
+	static int k;
+	static int[][] memo;
+
+	public static void main(String[] args) {
+		System.out.println(numDistinct("rabbbit", "rabbit"));
+	}
+	public static int numDistinct(String s, String t) {
+		Solution.s = s; Solution.t = t;
+		n = s.length();
+		k = t.length();
+		memo = new int[n + 1][k + 1];
+		for (int i = 0; i <= n; i++) {
+			Arrays.fill(memo[i], -1);
+		}
+
+		return backtrack(0, 0);
+    }
+
+	static int backtrack(int idx, int count) {
+		if (memo[idx][count] != -1) return memo[idx][count];
+		if (idx == n) {
+			if (count != k) return 0;
+		}
+		if (count == k) return 1;
+
+		int result = 0;
+		if (s.charAt(idx) == t.charAt(count)) {
+			result += backtrack(idx + 1, count + 1);
+		}
+		result += backtrack(idx + 1, count);
+
+		memo[idx][count] = result;
+		return memo[idx][count];
+	}
+
+}

--- a/dong99u/leetcode/811.java
+++ b/dong99u/leetcode/811.java
@@ -1,0 +1,40 @@
+package leetcode.leetcode811;
+
+import java.util.*;
+import java.util.stream.*;
+
+/**
+ * .을 기준으로 split 한 다음 해시맵 사용해서 더해주기.
+ */
+public class Solution {
+
+
+	public static void main(String[] args) {
+		String[] cpdomains = {"900 google.mail.com", "50 yahoo.com", "1 intel.mail.com", "5 wiki.org"};
+
+		List<String> strings = subdomainVisits(cpdomains);
+
+		for (String string : strings) {
+			System.out.println(string);
+		}
+	}
+
+	public static List<String> subdomainVisits(String[] cpdomains) {
+        Map<String, Integer> hashMap = new HashMap<>();
+
+        for (String cpdomain : cpdomains) {
+            String[] split = cpdomain.split(" ");
+            int num = Integer.parseInt(split[0]);
+            String[] splitDomain = split[1].split("\\.");
+
+            for (int i = 0; i < splitDomain.length; i++) {
+                String key = String.join(".", Arrays.copyOfRange(splitDomain, i, splitDomain.length));
+                hashMap.merge(key, num, Integer::sum);
+            }
+        }
+
+        return hashMap.entrySet().stream()
+            .map(e -> e.getValue() + " " + e.getKey())
+            .collect(Collectors.toList());
+    }
+}

--- a/dong99u/programmers/바이러스 파이프.java
+++ b/dong99u/programmers/바이러스 파이프.java
@@ -1,0 +1,137 @@
+package programmers.programmers468373;
+
+import java.util.*;
+
+/**
+ * 1. 문제 이해
+ *
+ * 트리 구조 (n ≤ 100), 초기 감염 노드 1개
+ * type 1/2/3 중 하나를 골라 그 type 간선으로 BFS 전파를 최대 k번 (k ≤ 10) 반복
+ * 최종 감염 노드 수의 최댓값
+ *
+ * 2. Brute Force 설계 (백트래킹)
+ * 상태 트리:
+ *                    backtrack(0)
+ *               /         |         \
+ *           type=1      type=2      type=3
+ *          (BFS전파)   (BFS전파)   (BFS전파)
+ *         /  |  \      /  |  \     /  |  \
+ *        1   2   3    1   2   3   1   2   3
+ *        ⋮
+ *        (깊이 k)
+ *
+ * 각 분기에서 type 3가지 중 하나 선택 → 중복 순열
+ * 파라미터: count (현재까지 행동 횟수)
+ * 부수 상태: visited[] (감염 여부)
+ * 한 번의 행동(BFS) 효과: 감염된 노드들에서 시작하는 multi-source BFS로 같은 type 간선을 따라 전파
+ *
+ * 3. 복잡도 분석
+ *
+ * 분기 수: O(3^k) = O(3^10) ≈ 5.9 × 10^4
+ * 각 분기의 BFS: O(V + E) = O(n) (트리이므로 E = n-1)
+ * 총: O(3^k · n) ≈ 6 × 10^6 → Java로 충분히 통과
+ *
+ * 4. 메모이제이션 가능성 검토
+ *
+ * 상태 공간이 DAG임
+ * 같은 상태가 여러 경로로 도달? → 이론상 가능 (예: A→B와 B→A가 같은 visited 집합으로 수렴 가능)
+ * 그러나 memo 키가 (count, visited 집합)이 되어야 하는데, n=100이라 비트마스크 표현이 비실용적
+ * 결론: 메모이제이션은 히트율이 낮고, 3^k 자체가 충분히 작아 가지치기 + 직접 탐색으로 통과 가능
+ *
+ * 5. 핵심 구현 포인트
+ * ① Multi-source BFS
+ *
+ * 매 행동 시 "현재 감염된 모든 노드"를 큐에 넣고 시작 → 같은 type 간선을 따라 전파
+ *
+ * ② Bulk undo (백트래킹 복구)
+ *
+ * BFS는 여러 노드의 visited를 한 번에 변경하므로, 새로 감염된 노드 리스트를 반환해서 일괄 복구
+ * List<Integer> newInfected = bfs(type);
+ * // 재귀 호출
+ * for (int i : newInfected) visited[i] = false;  // 일괄 undo
+ *
+ * ③ 자연 가지치기
+ *
+ * newInfected.isEmpty()면 continue → 해당 type은 무의미한 선택이므로 스킵
+ *
+ * ④ 누적 결과 처리 (방식 B - backward)
+ *
+ * framework의 인자/리턴값 판별 기준 적용:
+ *
+ * acc(현재까지 감염 수)는 기저 조건 판정에도, 가지치기에도 불필요
+ * 따라서 acc는 인자가 아닌 리턴값으로 수집 (방식 B)
+ * 리턴값 = newInfected.size() + backtrack(count + 1) 누적
+ *
+ *
+ * ⑤ 최초 감염 노드 보정
+ *
+ * backtrack(0)은 "행동 이후 새로 감염된 수"만 리턴 → 최초 감염 노드 1개를 마지막에 더해줌
+ * return backtrack(0) + 1;
+ */
+public class Solution {
+	static List<List<int[]>> graph;
+	static int n;
+	static int infection;
+	static int k;
+	static boolean[] visited;
+
+
+	public static int solution(int n, int infection, int[][] edges, int k) {
+    	Solution.n = n; Solution.k = k; Solution.infection = infection;
+		visited = new boolean[n + 1];
+
+		graph = new ArrayList<>();
+		visited[infection] = true;
+		for (int i = 0; i <= n; i++) {
+			graph.add(new ArrayList<>());
+		}
+
+		for (int[] edge : edges) {
+			int u = edge[0], v = edge[1], type = edge[2];
+			graph.get(u).add(new int[] {v, type});
+			graph.get(v).add(new int[] {u, type});
+		}
+
+		return backtrack(0) + 1;
+	}
+
+	static int backtrack(int count) {
+		if (count == k)
+			return 0;
+
+		int best = 0;
+		for (int type = 1; type <= 3; type++) {
+			List<Integer> newInfected = bfs(type);
+
+			if (newInfected.isEmpty()) continue;
+
+			best = Math.max(best, newInfected.size() + backtrack(count + 1));
+			for (int i : newInfected) visited[i] = false;
+		}
+		return best;
+	}
+
+	static List<Integer> bfs(int type) {
+		Queue<Integer> queue = new ArrayDeque<>();
+		List<Integer> result = new ArrayList<>(); // 새로 감염된 노드들
+
+		for (int i = 1; i <= n; i++) {
+			if (visited[i]) queue.add(i);
+		}
+
+		while (!queue.isEmpty()) {
+			int curr = queue.poll();
+
+			for (int[] next : graph.get(curr)) {
+				int nextNode = next[0], nextType = next[1];
+				if (!visited[nextNode] && nextType == type) {
+					visited[nextNode] = true;
+					queue.add(nextNode);
+					result.add(nextNode);
+				}
+			}
+		}
+		return result;
+	}
+
+}


### PR DESCRIPTION
## 관련 Issue
issue: #60, #64 , #69 

## 풀이 설명
### 문제 1 [Subdomain Visit Count]
<!-- 풀이 접근법 -->
해시맵을 사용해서 더해주기.

### 문제 2 [바이러스 파이프]
<!-- 풀이 접근법 -->
트리에서 type(1/2/3)을 최대 k번 골라 multi-source BFS 전파 → 최대 감염 노드 수
각 행동마다 3가지 type 중 선택 → 중복 순열 백트래킹, 깊이 k
O(3^k · n) ≈ 3^10 × 100 ≈ 6×10^6 
상태 공간: visited 단조 증가 → DAG지만, n=100이라 비트마스크 메모이제이션은 비실용적 → 가지치기만으로 통과
누적 결과 처리: acc가 기저/가지치기 판정에 불필요 -> 리턴값으로 수집
부수 상태 복구: BFS가 여러 노드를 동시 변경 → 새로 감염된 노드 리스트 반환해서 visited 되돌리기


### 문제 3 [Distinct Subsequences]
<!-- 풀이 접근법 -->
각 i번째 문자열을 선택/비선택으로 분기해서 비교. -> 백트래킹
len(s), len(t) <= 1000 이므로 O(2^n) 은 TLE.
백트래킹 -> 메모이제이션으로 최적화.

## 시간/공간 복잡도
| 문제 | 시간 | 공간 |
|------|------|------|
| 문제 1 | O(n * L^2) | O(nL) |
| 문제 2 | O(3^k · n) |  |
| 문제 3 | O(nk) | O(n·k) |
