### PR TITLE
20260501 #60, #64, #69

### DIFF
--- a/jinbeom/115.py
+++ b/jinbeom/115.py
@@ -1,0 +1,14 @@
+class Solution:
+    def numDistinct(self, s: str, t: str) -> int:
+        n, m = len(s), len(t)
+        dp = [[0] * m for _ in range(n)]
+
+        dp[n - 1][m - 1] = int(s[n - 1] == t[m - 1])
+        for i in range(n - 2, -1, -1):
+            dp[i][m - 1] = int(s[i] == t[m - 1]) + dp[i + 1][m - 1]
+
+        for i in range(n - 2, -1, -1):
+            for j in range(m - 1):
+                dp[i][j] = dp[i + 1][j] + dp[i + 1][j + 1] * (s[i] == t[j])
+
+        return dp[0][0]

--- a/jinbeom/811.py
+++ b/jinbeom/811.py
@@ -1,0 +1,15 @@
+from collections import defaultdict
+
+class Solution:
+    def subdomainVisits(self, cpdomains: List[str]) -> List[str]:
+        result=defaultdict(int)
+        for cpdomain in cpdomains:
+            cnt,domain=cpdomain.split(' ')
+            cnt=int(cnt)
+            tmp=domain.split('.')
+            for idx in range(len(tmp)):
+                result[".".join(tmp[idx:])]+=cnt
+        ret=[]
+        for domain in result:
+            ret.append(str(result[domain])+" "+domain)
+        return ret

--- a/jinbeom/virus_pipe.py
+++ b/jinbeom/virus_pipe.py
@@ -1,0 +1,41 @@
+def solution(n, infection, edges, k):
+    global ret
+    answer = 0
+    adj=[[set(),set(),set()] for _ in range(n)]
+    visit=[[False]*3 for _ in range(n)]
+    graph=[[set(),set(),set()] for _ in range(n)]
+    for x,y,type in edges:
+        graph[x-1][type-1].add(y-1)
+        graph[y-1][type-1].add(x-1)
+    for x in range(n):
+        for idx in range(3):
+            if visit[x][idx]: continue
+            q=[x]
+            visit[x][idx]=True
+            tmp={x}
+            while q:
+                now=q.pop()
+                for nxt in graph[now][idx]:
+                    if not visit[nxt][idx]:
+                        q.append(nxt)
+                        visit[nxt][idx]=True
+                        tmp.add(nxt)
+            for y in tmp:
+                adj[y][idx]=tmp
+    ret=0
+
+    def select_pipe(infected, prev, t):
+        global ret
+        if t==0:
+            ret=max(ret,len(infected))
+            return
+        for idx in range(3):
+            if idx==prev: continue
+            tmp=set()
+            for x in infected:
+                tmp|=adj[x][idx]
+            select_pipe(infected|tmp,idx,t-1)
+
+    select_pipe({infection-1},-1,k)
+
+    return ret


### PR DESCRIPTION
## 관련 Issue
issue: #60, #64, #69

## 풀이 설명
### 문제 1 [Subdomain Visit Count]
<!-- 풀이 접근법 -->
도메인을 key로 맵 생성

### 문제 2 [바이러스 파이프]
<!-- 풀이 접근법 -->
간선 타입별로 연결 요소들을 미리 구한 다음 k번 동안 어느 파이프 선택할지 완전탐색


### 문제 3 [Distinct Subsequences]
<!-- 풀이 접근법 -->
원본 문자열의 i번째 인덱스부터 시작, 타겟 문자열의 j번째 인덱스부터 시작하는 문제 조건 만족하는 subsequence개수
dp[i][j]
=dp[i+1][j]+(i번째 문자와 j번째 문자가 같은 경우)dp[i+1][j+1]

## 시간/공간 복잡도
| 문제 | 시간 | 공간 |
|------|------|------|
| 문제 1 | 3nl | 3nl |
| 문제 2 | n^2*3*2^9 | n |
| 문제 3 | nm | nm |
