### PR TITLE
20260528 #135, #136

### DIFF
--- a/minuk/leetcode/1466.py
+++ b/minuk/leetcode/1466.py
@@ -1,0 +1,25 @@
+class Solution:
+    def minReorder(self, n: int, connections: List[List[int]]) -> int:
+        edges = [[] for _ in range(n + 1)]
+        reverse_edges = [[] for _ in range(n + 1)]
+        for a, b in connections:
+            edges[b].append(a)
+            reverse_edges[a].append(b)
+        
+        ans = 0
+        q = [0]
+        visited = [0 for i in range(n + 1)]
+        visited[0] = 1
+        while q:
+            node = q.pop()
+            for idx in edges[node]:
+                if (not visited[idx]):
+                    visited[idx] = 1
+                    q.append(idx)
+            for idx in reverse_edges[node]:
+                if (not visited[idx]):
+                    visited[idx] = 1
+                    q.append(idx)
+                    ans += 1
+
+        return ans

--- a/minuk/leetcode/2959.py
+++ b/minuk/leetcode/2959.py
@@ -1,0 +1,28 @@
+class Solution:
+    def numberOfSets(self, n: int, maxDistance: int, roads: List[List[int]]) -> int:
+        mat = [[int(1e9)] * (n + 1) for _ in range(n + 1)]
+        for i in range(n):
+            mat[i][i] = 0
+
+        for a, b, c in roads:
+            mat[a][b] = min(mat[a][b], c)
+            mat[b][a] = min(mat[b][a], c)
+        
+        res = 0
+        for mask in range(1 << n):
+            mat_copy = [mat[i][:] for i in range(n + 1)]
+            
+            for k in range(n):
+                for i in range(n):
+                    for j in range(n):
+                        now_mask = (1 << k) | (1 << i) | (1 << j)
+                        if ((mask & now_mask) == now_mask):
+                            mat_copy[i][j] = min(mat_copy[i][j], mat_copy[i][k] + mat_copy[k][j])
+            cnt = 0
+            for i in range(n):
+                for j in range(n):
+                    if ((mask & (1 << i)) and (mask & (1 << j))):
+                        cnt = max(cnt, mat_copy[i][j])
+            res += 1 if (cnt <= maxDistance) else 0
+        
+        return res


### PR DESCRIPTION
## 관련 Issue
issue: #135, #136

## 풀이 설명
### 문제 1 [[Reorder Routes to Make All Paths Lead to the City Zero](https://leetcode.com/problems/reorder-routes-to-make-all-paths-lead-to-the-city-zero/)] (#135)
<!-- 풀이 접근법 -->
`알고리즘 분류: graph, 그래프 탐색`
`문제 풀이 시간: 15분`
트리 형태의 그래프니까 0에서 출발하여 역방향 간선을 타고 가다가, 만약 정방향 간선으로 가야 하는 상황이면 카운트 값을 1씩 올리면서 계산


### 문제 2 [[Number of Possible Sets of Closing Branches](https://leetcode.com/problems/number-of-possible-sets-of-closing-branches/)] (#136)
<!-- 풀이 접근법 -->
`알고리즘 분류: graph, bitmasking, 플로이드 와샬`
`문제 풀이 시간: 30분`
n이 최대 10이라서 이런 문제는 보통 비트마스킹을 쓰라고 만든 문제일 확률이 높았음. 
비트마스킹으로 모든 경우의 수를 탐색하면서, 플로이드 와샬을 이용하여 i -> j로 가는 최대 비용을 계산하고, 그 중 maxDistance 보다 작거나 같은 경우만 결과값에 추가


## 시간/공간 복잡도
| 문제 | 시간 | 공간 |
|------|------|------|
| 문제 1 | O(V + E) / 115 ms | O(V + 2 * E) / 38.7 MB |
| 문제 2 | O(2 ^ N * N ^ 3) / 2506 ms | O(N ^ 2) / 19.3 MB |
