### PR TITLE
20260528 #135, #136

### DIFF
--- a/wooseok/LeetCode/1466_Reorder_Routes_to_Make_All_Paths_Lead_to_the_City_Zero.py
+++ b/wooseok/LeetCode/1466_Reorder_Routes_to_Make_All_Paths_Lead_to_the_City_Zero.py
@@ -1,0 +1,33 @@
+from collections import deque
+
+class Solution:
+    def minReorder(self, n: int, connections: List[List[int]]) -> int:
+        """
+        양방향으로 최단거리를 코스트를 추가해서 구하자
+        바뀌어야 되는 경우엔 cost 1부여
+        그 이후 다익스트라해서 dist sum을 하려고 했는데 여러 번 바꾸는 경우가 발생할 수도 있네
+
+        경로 체크가 있긴 해야될듯
+        순수 bfs로 하면 될 듯
+        """
+        INF = int(1e9)
+
+        graph = [[] for _ in range(n + 1)]
+        for a, b in connections:
+            graph[a].append((b, 1))  # 0부터 돌릴 것이므로 cost는 반대로 부여
+            graph[b].append((a, 0))
+        
+        q = deque([0])
+        visited = [False] * n
+        visited[0] = True
+        res = 0
+        while q:
+            cur = q.popleft()
+            for nxt, nxt_cost in graph[cur]:
+                if not visited[nxt]:
+                    q.append(nxt)
+                    visited[nxt] = True
+                    if nxt_cost == 1:
+                        res += 1
+        
+        return res

--- a/wooseok/LeetCode/2959_Number_of_Possible_Sets_of_Closing_Branches.py
+++ b/wooseok/LeetCode/2959_Number_of_Possible_Sets_of_Closing_Branches.py
@@ -1,0 +1,56 @@
+class Solution:
+    def numberOfSets(self, n: int, maxDistance: int, roads: List[List[int]]) -> int:
+        """
+        조합 만들어서 최단거리 구해고, 최단거리가 maxDistance보다 작게 모두 갈 수 있는 개수
+        n <= 10
+        => bitmasking + floyd-warshall 2^n * n^3
+        """
+
+        INF = int(1e6)
+
+        res = 0
+
+        for mask in range(1 << n):
+            dist = [[INF] * n for _ in range(n)]
+            for x in range(n):
+                dist[x][x] = 0
+
+            for u, v, w in roads:
+                if (mask & (1 << u)) and (mask & (1 << v)):
+                    if dist[u][v] > w:
+                        dist[u][v] = w
+                        dist[v][u] = w
+            
+            for k in range(n):
+                if not (mask & (1 << k)):
+                    continue
+                
+                for i in range(n):
+                    if not (mask & (1 << i)):
+                        continue
+                    for j in range(n):
+                        if not (mask & (1 << j)):
+                            continue
+                        
+                        if dist[i][k] + dist[k][j] < dist[i][j]:
+                            dist[i][j] = dist[i][k] + dist[k][j]
+            
+            # 조건 확인
+            flag = True
+            for i in range(n):
+                if not (mask & (1 << i)):
+                    continue
+                for j in range(n):
+                    if not (mask & (1 << j)):
+                        continue
+                    if dist[i][j] > maxDistance:
+                        flag = False
+                        break
+                
+                if not flag:
+                    break
+            
+            if flag:
+                res += 1
+        
+        return res


### PR DESCRIPTION
## 관련 Issue
issue: #135, #136

## 풀이 설명
### 문제 1 [Reorder Routes to Make All Paths Lead to the City Zero](https://leetcode.com/problems/reorder-routes-to-make-all-paths-lead-to-the-city-zero/) (#135)
<!-- 풀이 접근법 -->
`알고리즘 분류: BFS`
`문제 풀이 시간: 15m`
처음에 양방향으로 최단거리를 코스트를 추가해서 구하자고 생각
바뀌어야 되는 경우엔 cost 1부여
그 이후 다익스트라해서 dist배열을 구해서 sum을 하려고 했는데 여러 번 바꾸는 경우가 발생할 수도 있어서 경로 체크를 할 필요가 있음
그러면 BFS가 더 깔끔함

0부터 시작을 하도록 역방향으로 하므로 cost는 반대로 부여
ex)
input: u, v
u -> v : cost 1
v -> u : cost 0


### 문제 2 [Number of Possible Sets of Closing Branches](https://leetcode.com/problems/number-of-possible-sets-of-closing-branches/) (#136)
<!-- 풀이 접근법 -->
`알고리즘 분류: Bitmask(조합), 플로이드워셜`
`문제 풀이 시간: 27m`
문제 이해에 오래걸린 문제
특정 노드를 닫고 닫은 노드를 제외하고 노드간 거리가 maxDistance 이하로 처리해야 됨

N의 제약이 10이하로 크지 않으므로 완탐가능
노드를 닫는 것은 True/False로 처리 가능 -> 비트마스킹 2^N
노드 간 거리를 전부 구하려면 플로이드 워셜이 편함 N^3

## 시간/공간 복잡도
| 문제 | 시간 | 공간 |
|------|------|------|
| 문제 1 | O(N) / 103ms | O(NE) / 40.04MB |
| 문제 2 | O(2^N * N^3) / 654ms | O(N^2) / 19.6MB |
